### PR TITLE
Adds IPAdapter support by switching attention to IpAdapter attention

### DIFF
--- a/tgate/PixArt_Alpha.py
+++ b/tgate/PixArt_Alpha.py
@@ -254,7 +254,7 @@ def tgate(
     # 7. Denoising loop
     num_warmup_steps = max(len(timesteps) - num_inference_steps * self.scheduler.order, 0)
     register_forward(self.transformer, 
-        'Attention',
+        'IPAdapterAttnProcessor2_0',
         ca_kward = {
             'cache': False,
             'reuse': False,
@@ -304,7 +304,7 @@ def tgate(
                 )
                 keep_shape = keep_shape if not lcm else lcm
                 register_forward(self.transformer, 
-                    'Attention',
+                    'IPAdapterAttnProcessor2_0',
                     ca_kward=ca_kwards,
                     sa_kward=sa_kwards,
                     keep_shape=keep_shape

--- a/tgate/PixArt_Sigma.py
+++ b/tgate/PixArt_Sigma.py
@@ -242,7 +242,7 @@ def tgate(
     # 7. Denoising loop
     num_warmup_steps = max(len(timesteps) - num_inference_steps * self.scheduler.order, 0)
     register_forward(self.transformer,
-        'Attention',
+        'IPAdapterAttnProcessor2_0',
         ca_kward = {
             'cache': False,
             'reuse': False,
@@ -292,7 +292,7 @@ def tgate(
                 )
                 keep_shape = keep_shape if not lcm else lcm
                 register_forward(self.transformer,
-                    'Attention',
+                    'IPAdapterAttnProcessor2_0',
                     ca_kward=ca_kwards,
                     sa_kward=sa_kwards,
                     keep_shape=keep_shape

--- a/tgate/SD.py
+++ b/tgate/SD.py
@@ -276,7 +276,7 @@ def tgate(
     self._num_timesteps = len(timesteps)
 
     register_forward(self.unet, 
-        'Attention',
+        'IPAdapterAttnProcessor2_0',
         ca_kward = {
             'cache': False,
             'reuse': False,
@@ -311,7 +311,7 @@ def tgate(
                     warm_up=warm_up
                 )
                 register_forward(self.unet, 
-                    'Attention',
+                    'IPAdapterAttnProcessor2_0',
                     ca_kward=ca_kwards,
                     sa_kward=sa_kwards,
                     keep_shape=keep_shape

--- a/tgate/SDXL.py
+++ b/tgate/SDXL.py
@@ -417,7 +417,7 @@ def tgate(
     self._num_timesteps = len(timesteps)
 
     register_forward(self.unet, 
-        'Attention',
+        'IPAdapterAttnProcessor2_0',
         ca_kward = {
             'cache': False,
             'reuse': False,
@@ -460,7 +460,7 @@ def tgate(
                 )
                 keep_shape = keep_shape if not lcm else lcm
                 register_forward(self.unet, 
-                    'Attention',
+                    'IPAdapterAttnProcessor2_0',
                     ca_kward=ca_kwards,
                     sa_kward=sa_kwards,
                     keep_shape=keep_shape

--- a/tgate/SDXL_DeepCache.py
+++ b/tgate/SDXL_DeepCache.py
@@ -416,7 +416,7 @@ def tgate(
     self._num_timesteps = len(timesteps)
 
     register_forward(self.unet, 
-        'Attention',
+        'IPAdapterAttnProcessor2_0',
         ca_kward = {
             'cache': False,
             'reuse': False,
@@ -466,7 +466,7 @@ def tgate(
                     'reuse': False,
                 }
                 register_forward(self.unet, 
-                    'Attention',
+                    'IPAdapterAttnProcessor2_0',
                     ca_kward=ca_kwards,
                     sa_kward=sa_kwards,
                     keep_shape=keep_shape

--- a/tgate/SD_DeepCache.py
+++ b/tgate/SD_DeepCache.py
@@ -276,7 +276,7 @@ def tgate(
     self._num_timesteps = len(timesteps)
 
     register_forward(self.unet, 
-        'Attention',
+        'IPAdapterAttnProcessor2_0',
         ca_kward = {
             'cache': False,
             'reuse': False,
@@ -315,7 +315,7 @@ def tgate(
                     warm_up=warm_up
                 )
                 register_forward(self.unet, 
-                    'Attention',
+                    'IPAdapterAttnProcessor2_0',
                     ca_kward=ca_kwards,
                     sa_kward=sa_kwards,
                     keep_shape=keep_shape

--- a/tgate/SVD.py
+++ b/tgate/SVD.py
@@ -244,7 +244,7 @@ def tgate(
     num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
 
     register_forward(self.unet, 
-        'Attention',
+        'IPAdapterAttnProcessor2_0',
         ca_kward = {
             'cache': False,
             'reuse': False,


### PR DESCRIPTION
This PR adopts [IPAdapterAttnProcessor2_0](https://github.com/huggingface/diffusers/blob/v0.29.2/src/diffusers/models/attention_processor.py#L2700) instead of [AttnProcessor2_0](https://github.com/huggingface/diffusers/blob/v0.29.2/src/diffusers/models/attention_processor.py#L1518) in [tgate_utils.py](https://github.com/HaozheLiu-ST/T-GATE/blob/main/tgate/tgate_utils.py) to support IP Adapters.

**How to run:**
```bash
python main.py \
--prompt 'Astronaut in a jungle, cold color palette, muted colors, detailed, 8k' \
--model 'sdxl' \
--gate_step 10 \
--sp_interval 5 \
--fi_interval 1 \
--warm_up 2 \
--saved_path './generated_tmp/sd_xl/' \
--inference_step 25 \
```  